### PR TITLE
Add dark mode support

### DIFF
--- a/client/AboutPanel.tsx
+++ b/client/AboutPanel.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import IconButton from './IconButton';
 import TextWithLink from './TextWithLink';
+import { useTheme, ThemeColors } from './ThemeContext';
 
 export interface AboutPanelProps {
     code: string;
@@ -15,6 +16,9 @@ export interface AboutPanelProps {
 }
 
 export function AboutPanel(props: AboutPanelProps) {
+    const { colors } = useTheme();
+    const styles = makeStyles(colors);
+
     return (
         <View style={styles.container}>
             <Text style={styles.headerText} selectable={false}>
@@ -138,7 +142,9 @@ interface CopyToClipboardButtonState {
 }
 
 function CopyToClipboardButton(props: CopyToClipboardButtonProps) {
+    const { colors } = useTheme();
     const [buttonState, setButtonState] = useState<CopyToClipboardButtonState>({ isCopied: false });
+    const styles = makeStyles(colors);
 
     return (
         <View style={styles.clipboardContainer}>
@@ -161,8 +167,8 @@ function CopyToClipboardButton(props: CopyToClipboardButtonProps) {
                         // Ignore the error.
                     }
                 }}
-                color={buttonState.isCopied ? '#090' : '#666'}
-                hoverColor={buttonState.isCopied ? '#090' : '#333'}
+                color={buttonState.isCopied ? colors.success : colors.textSecondary}
+                hoverColor={buttonState.isCopied ? colors.success : colors.text}
                 backgroundStyle={styles.clipboardButtonBackground}
                 hoverBackgroundStyle={styles.clipboardButtonBackgroundHover}
             />
@@ -173,17 +179,18 @@ function CopyToClipboardButton(props: CopyToClipboardButtonProps) {
     );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     container: {
         flex: 1,
         flexDirection: 'column',
         alignSelf: 'stretch',
         paddingVertical: 8,
         paddingHorizontal: 12,
+        backgroundColor: colors.surface,
     },
     headerText: {
         fontSize: 14,
-        color: '#666',
+        color: colors.textSecondary,
         marginBottom: 8,
         fontVariant: ['small-caps'],
     },
@@ -197,13 +204,13 @@ const styles = StyleSheet.create({
         marginLeft: 16,
         marginRight: 8,
         fontSize: 13,
-        color: '#333',
+        color: colors.text,
         marginBottom: 8,
     },
     divider: {
         height: 1,
         borderTopWidth: 1,
-        borderColor: '#eee',
+        borderColor: colors.border,
         borderStyle: 'solid',
         marginVertical: 8,
     },
@@ -218,19 +225,19 @@ const styles = StyleSheet.create({
         width: 26,
         paddingVertical: 4,
         paddingHorizontal: 4,
-        backgroundColor: '#fff',
+        backgroundColor: colors.background,
         borderWidth: 1,
         borderRadius: 4,
         borderStyle: 'solid',
-        borderColor: '#999',
+        borderColor: colors.border,
     },
     clipboardButtonBackgroundHover: {
-        borderColor: '#666',
+        borderColor: colors.textSecondary,
     },
     clipboardButtonText: {
         marginLeft: 8,
         fontSize: 13,
-        color: '#333',
+        color: colors.text,
         marginBottom: 2,
     },
 });

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -14,6 +14,7 @@ import { MonacoEditor } from './MonacoEditor';
 import { PlaygroundSettings } from './PlaygroundSettings';
 import { ProblemsPanel } from './ProblemsPanel';
 import { RightPanel, RightPanelType } from './RightPanel';
+import { ThemeProvider, useTheme } from './ThemeContext';
 import { getStateFromUrl, updateUrlFromState } from './UrlUtils';
 import { getPyrightVersions } from './sessionManager'
 
@@ -38,8 +39,9 @@ export interface AppState {
 
 const initialState = getStateFromUrl() ?? getInitialStateFromLocalStorage();
 
-export default function App() {
+function AppContent() {
     const editorRef = useRef(null);
+    const { colors } = useTheme();
     const [appState, setAppState] = useState<AppState>({
         gotInitialState: false,
         code: '',
@@ -172,7 +174,7 @@ export default function App() {
 
     return (
         <MenuProvider>
-            <View style={styles.container}>
+            <View style={[styles.container, { backgroundColor: colors.background }]}>
                 <HeaderPanel
                     isRightPanelDisplayed={appState.isRightPanelDisplayed}
                     rightPanelType={appState.rightPanelType}
@@ -223,6 +225,14 @@ export default function App() {
                 />
             </View>
         </MenuProvider>
+    );
+}
+
+export default function App() {
+    return (
+        <ThemeProvider>
+            <AppContent />
+        </ThemeProvider>
     );
 }
 

--- a/client/CheckmarkMenu.tsx
+++ b/client/CheckmarkMenu.tsx
@@ -7,6 +7,7 @@ import * as icons from '@ant-design/icons-svg';
 import { ScrollView, StyleSheet, TextInput, View } from 'react-native';
 import { MenuItem } from './Menu';
 import { createRef, useEffect, useState } from 'react';
+import { useTheme, ThemeColors } from './ThemeContext';
 
 export interface CheckmarkMenuProps {
     items: CheckmarkMenuItem[];
@@ -28,10 +29,12 @@ interface CheckmarkMenuState {
 }
 
 export function CheckmarkMenu(props: CheckmarkMenuProps) {
+    const { colors } = useTheme();
     const [state, setState] = useState<CheckmarkMenuState>({
         searchFilter: '',
     });
     const textInputRef = createRef<TextInput>();
+    const styles = makeStyles(colors);
 
     const searchFilter = state.searchFilter.toLowerCase().trim();
     const filteredItems = props.items.filter((item) => {
@@ -59,7 +62,7 @@ export function CheckmarkMenu(props: CheckmarkMenuProps) {
                         style={styles.searchBox}
                         value={state.searchFilter}
                         placeholder={'Search'}
-                        placeholderTextColor={'#ccc'}
+                        placeholderTextColor={colors.textSecondary}
                         onChangeText={(newValue) => {
                             setState((prevState) => {
                                 return { ...prevState, searchFilter: newValue };
@@ -98,7 +101,7 @@ export function CheckmarkMenu(props: CheckmarkMenuProps) {
     );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     container: {
         flexDirection: 'column',
         minWidth: 100,
@@ -110,15 +113,16 @@ const styles = StyleSheet.create({
         paddingTop: 4,
         paddingBottom: 8,
         borderBottomWidth: 1,
-        borderBottomColor: '#ccc',
+        borderBottomColor: colors.border,
         borderStyle: 'solid',
     },
     searchBox: {
         fontSize: 13,
         padding: 4,
         borderWidth: 1,
-        borderColor: '#ccc',
+        borderColor: colors.border,
         borderStyle: 'solid',
-        backgroundColor: '#fff',
+        backgroundColor: colors.background,
+        color: colors.text,
     },
 });

--- a/client/HeaderPanel.tsx
+++ b/client/HeaderPanel.tsx
@@ -8,6 +8,7 @@ import { Image, Linking, Pressable, StyleSheet, Text, View } from 'react-native'
 import { useAssets } from 'expo-asset';
 import IconButton from './IconButton';
 import { RightPanelType } from './RightPanel';
+import { useTheme, ThemeColors } from './ThemeContext';
 
 const headerIconButtonSize = 20;
 
@@ -18,7 +19,9 @@ export interface HeaderPanelProps {
 }
 
 export function HeaderPanel(props: HeaderPanelProps) {
+    const { colors } = useTheme();
     const [assets, error] = useAssets([require('./assets/pyright_bw.png')]);
+    const styles = makeStyles(colors);
 
     let image = null;
     if (!error && assets) {
@@ -47,9 +50,9 @@ export function HeaderPanel(props: HeaderPanelProps) {
                         props.isRightPanelDisplayed &&
                         props.rightPanelType === RightPanelType.Settings
                     }
-                    color={'#fff'}
-                    hoverColor={'#eee'}
-                    disableColor={'#ffaa00'}
+                    color={colors.text}
+                    hoverColor={colors.textSecondary}
+                    disableColor={colors.accent}
                     title={'Playground settings'}
                     onPress={() => {
                         props.onShowRightPanel(RightPanelType.Settings);
@@ -62,8 +65,8 @@ export function HeaderPanel(props: HeaderPanelProps) {
                         props.isRightPanelDisplayed && props.rightPanelType === RightPanelType.About
                     }
                     color={'#fff'}
-                    hoverColor={'#eee'}
-                    disableColor={'#ffaa00'}
+                    hoverColor={colors.textSecondary}
+                    disableColor={colors.accent}
                     title={'About BasedPyright Playground'}
                     onPress={() => {
                         props.onShowRightPanel(RightPanelType.About);
@@ -74,7 +77,7 @@ export function HeaderPanel(props: HeaderPanelProps) {
     );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     container: {
         flex: -1,
         flexDirection: 'row',
@@ -84,6 +87,8 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         backgroundColor: '#000',
         height: 42,
+        borderBottomWidth: 1,
+        borderBottomColor: colors.border,
     },
     pyrightIcon: {
         height: 24,

--- a/client/HeaderPanel.tsx
+++ b/client/HeaderPanel.tsx
@@ -50,8 +50,8 @@ export function HeaderPanel(props: HeaderPanelProps) {
                         props.isRightPanelDisplayed &&
                         props.rightPanelType === RightPanelType.Settings
                     }
-                    color={colors.text}
-                    hoverColor={colors.textSecondary}
+                    color={'#fff'}
+                    hoverColor={'#eee'}
                     disableColor={colors.accent}
                     title={'Playground settings'}
                     onPress={() => {
@@ -65,7 +65,7 @@ export function HeaderPanel(props: HeaderPanelProps) {
                         props.isRightPanelDisplayed && props.rightPanelType === RightPanelType.About
                     }
                     color={'#fff'}
-                    hoverColor={colors.textSecondary}
+                    hoverColor={'#eee'}
                     disableColor={colors.accent}
                     title={'About BasedPyright Playground'}
                     onPress={() => {

--- a/client/Menu.tsx
+++ b/client/Menu.tsx
@@ -173,7 +173,7 @@ const makeStyles = (colors: ThemeColors, theme: Theme) => StyleSheet.create({
         marginRight: 4,
     },
     focused: {
-        backgroundColor: theme === 'light' ? '#eee' : colors.surface,
+        backgroundColor: colors.hover,
     },
     menuContainer: {
         margin: 4,

--- a/client/Menu.tsx
+++ b/client/Menu.tsx
@@ -15,10 +15,7 @@ import {
 } from 'react-native-popup-menu';
 import { useHover } from './HoverHook';
 import { SvgIcon } from './SvgIcon';
-
-export const menuIconColor = '#ffaa00';
-export const panelTextColor = '#222';
-export const focusedMenuItemBackgroundColor = '#eee';
+import { useTheme, ThemeColors, Theme } from './ThemeContext';
 
 export interface MenuProps extends React.PropsWithChildren {
     name: string;
@@ -32,7 +29,9 @@ export interface MenuRef {
 }
 
 export const Menu = forwardRef(function Menu(props: MenuProps, ref: ForwardedRef<MenuRef>) {
+    const { colors, theme } = useTheme();
     const menuRef = useRef<RNMenu>(null);
+    const styles = makeStyles(colors, theme);
 
     useImperativeHandle(ref, () => {
         return {
@@ -56,16 +55,12 @@ export const Menu = forwardRef(function Menu(props: MenuProps, ref: ForwardedRef
         >
             <MenuTrigger />
             <MenuOptions
-                customStyles={
-                    props.isPopup
-                        ? {
-                              optionsContainer: {
-                                  backgroundColor: 'transparent',
-                                  shadowOpacity: 0,
-                              },
-                          }
-                        : undefined
-                }
+                customStyles={{
+                    optionsContainer: {
+                        backgroundColor: 'transparent',
+                        shadowOpacity: 0,
+                    },
+                }}
             >
                 <View style={styles.menuContainer}>{props.children}</View>
             </MenuOptions>
@@ -84,7 +79,9 @@ export interface MenuItemProps {
 }
 
 export function MenuItem(props: MenuItemProps) {
+    const { colors, theme } = useTheme();
     const [hoverRef, isHovered] = useHover();
+    const styles = makeStyles(colors, theme);
 
     // If there's a label filter, see if we can find it in the label.
     let filterOffset = -1;
@@ -142,7 +139,7 @@ export function MenuItem(props: MenuItemProps) {
                             <SvgIcon
                                 iconDefinition={props.iconDefinition}
                                 iconSize={14}
-                                color={props.iconDefinition ? menuIconColor : 'transparent'}
+                                color={props.iconDefinition ? colors.accent : 'transparent'}
                             />
                         ) : undefined}
                     </View>
@@ -153,7 +150,7 @@ export function MenuItem(props: MenuItemProps) {
     );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (colors: ThemeColors, theme: Theme) => StyleSheet.create({
     container: {
         paddingVertical: 2,
         paddingHorizontal: 6,
@@ -176,18 +173,22 @@ const styles = StyleSheet.create({
         marginRight: 4,
     },
     focused: {
-        backgroundColor: focusedMenuItemBackgroundColor,
+        backgroundColor: theme === 'light' ? '#eee' : colors.surface,
     },
     menuContainer: {
         margin: 4,
+        backgroundColor: colors.background,
+        borderRadius: 4,
+        borderWidth: 1,
+        borderColor: colors.border,
     },
     labelText: {
         fontSize: 13,
         padding: 4,
-        color: panelTextColor,
+        color: colors.text,
     },
     labelFiltered: {
-        backgroundColor: '#ccc',
-        color: '#000',
+        backgroundColor: colors.accent,
+        color: colors.background,
     },
 });

--- a/client/Menu.tsx
+++ b/client/Menu.tsx
@@ -31,7 +31,7 @@ export interface MenuRef {
 export const Menu = forwardRef(function Menu(props: MenuProps, ref: ForwardedRef<MenuRef>) {
     const { colors, theme } = useTheme();
     const menuRef = useRef<RNMenu>(null);
-    const styles = makeStyles(colors, theme);
+    const styles = makeStyles(colors);
 
     useImperativeHandle(ref, () => {
         return {
@@ -81,7 +81,7 @@ export interface MenuItemProps {
 export function MenuItem(props: MenuItemProps) {
     const { colors, theme } = useTheme();
     const [hoverRef, isHovered] = useHover();
-    const styles = makeStyles(colors, theme);
+    const styles = makeStyles(colors);
 
     // If there's a label filter, see if we can find it in the label.
     let filterOffset = -1;
@@ -150,7 +150,7 @@ export function MenuItem(props: MenuItemProps) {
     );
 }
 
-const makeStyles = (colors: ThemeColors, theme: Theme) => StyleSheet.create({
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     container: {
         paddingVertical: 2,
         paddingHorizontal: 6,

--- a/client/MonacoEditor.tsx
+++ b/client/MonacoEditor.tsx
@@ -20,6 +20,7 @@ import {
     TextDocumentEdit,
 } from 'vscode-languageserver-types';
 import { LspClient } from './LspClient';
+import { useTheme, ThemeColors } from './ThemeContext';
 import { fromRange, toInlayHint, toRange, toSemanticTokens } from 'monaco-languageserver-types'
 
 // TODO: use monaco-languageserver-types for more conversaions. currently only used for inlay hints and semantic tokens
@@ -73,6 +74,7 @@ export const MonacoEditor = forwardRef(function MonacoEditor(
 ) {
     const editorRef = useRef(null);
     const monacoRef = useRef(null);
+    const { monacoTheme, colors } = useTheme();
 
     function handleEditorDidMount(
         editor: monaco.editor.IStandaloneCodeEditor,
@@ -150,6 +152,8 @@ export const MonacoEditor = forwardRef(function MonacoEditor(
         }
     }, [props.diagnostics]);
 
+    const styles = makeStyles(colors);
+
     return (
         <View style={styles.container}>
             <View style={styles.editor}>
@@ -157,7 +161,7 @@ export const MonacoEditor = forwardRef(function MonacoEditor(
                     options={options}
                     language={'python'}
                     value={props.code}
-                    theme="vs"
+                    theme={monacoTheme}
                     onChange={(value) => {
                         props.onUpdateCode(value);
                     }}
@@ -484,10 +488,11 @@ function getLspClientForModel(model: monaco.editor.ITextModel): LspClient | unde
     return registeredModels.find((m) => m.model === model)?.lspClient;
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     container: {
         flex: 1,
         paddingVertical: 4,
+        backgroundColor: colors.background,
     },
     editor: {
         position: 'absolute',

--- a/client/ProblemsPanel.tsx
+++ b/client/ProblemsPanel.tsx
@@ -19,6 +19,7 @@ import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-typ
 import { useHover } from './HoverHook';
 import { useEffect, useRef } from 'react';
 import { SvgIcon } from './SvgIcon';
+import { useTheme, ThemeColors } from './ThemeContext';
 
 export interface ProblemsPanelProps {
     diagnostics: Diagnostic[];
@@ -31,6 +32,8 @@ const problemsPanelHeight = 200;
 const problemsPanelHeightCollapsed = 32;
 
 export function ProblemsPanel(props: ProblemsPanelProps) {
+    const { colors } = useTheme();
+
     // We don't display hints in the problems panel.
     const filteredDiagnostics = props.diagnostics.filter(
         (diag) => diag.severity !== DiagnosticSeverity.Hint
@@ -52,6 +55,8 @@ export function ProblemsPanel(props: ProblemsPanelProps) {
         }).start();
     }, [heightAnimation, props.expandProblems]);
 
+    const styles = makeStyles(colors);
+
     return (
         <Animated.View style={[styles.animatedContainer, { height: heightAnimation }]}>
             <View style={styles.container}>
@@ -71,7 +76,7 @@ export function ProblemsPanel(props: ProblemsPanelProps) {
                                     <Text style={styles.waitingText} selectable={false}>
                                         Waiting for worker
                                     </Text>
-                                    <ActivityIndicator size={12} color="#fff" />
+                                    <ActivityIndicator size={12} color={colors.accent} />
                                 </View>
                             ) : undefined}
                         </View>
@@ -99,6 +104,8 @@ export function ProblemsPanel(props: ProblemsPanelProps) {
 
 function ProblemItem(props: { diagnostic: Diagnostic; onSelectRange: (range: Range) => void }) {
     const [hoverRef, isHovered] = useHover();
+    const { colors } = useTheme();
+    const styles = makeStyles(colors, isHovered);
 
     return (
         <Pressable
@@ -131,6 +138,9 @@ function ProblemItem(props: { diagnostic: Diagnostic; onSelectRange: (range: Ran
 }
 
 function NoProblemsItem() {
+    const { colors } = useTheme();
+    const styles = makeStyles(colors);
+
     return (
         <View style={styles.diagnosticContainer}>
             <View style={styles.diagnosticTextContainer}>
@@ -160,7 +170,7 @@ function ProblemIcon(props: { severity: DiagnosticSeverity }) {
     return <SvgIcon iconDefinition={iconDefinition} iconSize={14} color={iconColor} />;
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (colors: ThemeColors, isHovered = false) => StyleSheet.create({
     animatedContainer: {
         position: 'relative',
         alignSelf: 'stretch',
@@ -168,10 +178,11 @@ const styles = StyleSheet.create({
     container: {
         flexDirection: 'column',
         height: problemsPanelHeight,
-        borderTopColor: '#ccc',
+        borderTopColor: colors.border,
         borderTopWidth: 1,
         borderStyle: 'solid',
         alignSelf: 'stretch',
+        backgroundColor: colors.background,
     },
     header: {
         height: 32,
@@ -180,6 +191,8 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         alignSelf: 'stretch',
         alignItems: 'center',
+        borderBottomWidth: 1,
+        borderBottomColor: colors.border,
     },
     headerContents: {
         flex: 1,
@@ -194,7 +207,6 @@ const styles = StyleSheet.create({
     },
     problemCountText: {
         fontSize: 9,
-        color: 'black',
     },
     problemCountBubble: {
         marginLeft: 6,
@@ -213,15 +225,16 @@ const styles = StyleSheet.create({
     },
     waitingText: {
         fontSize: 12,
-        color: '#fff',
+        color: colors.textSecondary,
         marginRight: 8,
     },
     diagnosticContainer: {
         padding: 4,
         flexDirection: 'row',
+        backgroundColor: isHovered ? colors.surface : 'transparent',
     },
     problemContainerHover: {
-        backgroundColor: '#eee',
+        backgroundColor: colors.surface,
     },
     diagnosticIconContainer: {
         marginTop: 1,
@@ -231,8 +244,9 @@ const styles = StyleSheet.create({
     diagnosticText: {
         fontSize: 13,
         lineHeight: 16,
+        color: colors.text,
     },
     diagnosticSourceText: {
-        color: '#aaa',
+        color: colors.textSecondary,
     },
 });

--- a/client/PushButton.tsx
+++ b/client/PushButton.tsx
@@ -5,6 +5,7 @@
 
 import { Pressable, StyleSheet, Text, TextStyle, ViewStyle } from 'react-native';
 import { useHover } from './HoverHook';
+import { useTheme, ThemeColors } from './ThemeContext';
 
 interface PushButtonProps {
     label: string;
@@ -18,7 +19,9 @@ interface PushButtonProps {
 }
 
 export default function PushButton(props: PushButtonProps) {
+    const { colors } = useTheme();
     const [hoverRef, isHovered] = useHover();
+    const styles = makeStyles(colors);
 
     let effectiveBackgroundStyle: (ViewStyle | ViewStyle[] | undefined)[] = [
         styles.defaultBackground,
@@ -54,30 +57,30 @@ export default function PushButton(props: PushButtonProps) {
     );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     baseBackground: {
         flexDirection: 'row',
         paddingHorizontal: 12,
         paddingVertical: 6,
         borderRadius: 4,
         borderWidth: 1,
-        borderColor: '#ffaa00',
+        borderColor: colors.accent,
     },
     defaultBackground: {
-        backgroundColor: '#f8f8f8',
+        backgroundColor: colors.surface,
     },
     defaultHoverBackground: {
-        backgroundColor: '#fff',
+        backgroundColor: colors.background,
     },
     disabledBackground: {
         backgroundColor: 'transparent',
-        borderColor: '#ccc',
+        borderColor: colors.textSecondary,
     },
     disabledText: {
-        color: '#ccc',
+        color: colors.textSecondary,
     },
     baseText: {
-        color: '#333',
+        color: colors.text,
         fontSize: 13,
     },
 });

--- a/client/RightPanel.tsx
+++ b/client/RightPanel.tsx
@@ -112,6 +112,13 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
         alignSelf: 'stretch',
         backgroundColor: colors.surface,
     },
+    contentContainer: {
+        flexGrow: 1,
+        flexShrink: 0,
+        flexBasis: 0,
+        flexDirection: 'column',
+        alignSelf: 'stretch',
+    },
     headerContainer: {
         flexDirection: 'row',
         height: 36,
@@ -126,13 +133,6 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
         color: colors.text,
         fontSize: 14,
         fontWeight: 'bold',
-    },
-    contentContainer: {
-        flexGrow: 1,
-        flexShrink: 0,
-        flexBasis: 0,
-        flexDirection: 'column',
-        alignSelf: 'stretch',
     },
     headerControlsContainer: {
         flex: 1,

--- a/client/RightPanel.tsx
+++ b/client/RightPanel.tsx
@@ -10,6 +10,7 @@ import IconButton from './IconButton';
 import { AboutPanel } from './AboutPanel';
 import { SettingsPanel } from './SettingsPanel';
 import { PlaygroundSettings } from './PlaygroundSettings';
+import { useTheme, ThemeColors } from './ThemeContext';
 
 export enum RightPanelType {
     About,
@@ -31,6 +32,7 @@ export interface RightPanelProps {
 const rightPanelWidth = 320;
 
 export function RightPanel(props: RightPanelProps) {
+    const { colors } = useTheme();
     let panelContents: JSX.Element | undefined;
     let headerTitle = '';
 
@@ -72,6 +74,8 @@ export function RightPanel(props: RightPanelProps) {
         }).start();
     }, [widthAnimation, props.isRightPanelDisplayed]);
 
+    const styles = makeStyles(colors);
+
     return (
         <Animated.View style={[styles.animatedContainer, { width: widthAnimation }]}>
             <View style={styles.container}>
@@ -83,8 +87,8 @@ export function RightPanel(props: RightPanelProps) {
                         <IconButton
                             iconDefinition={icons.CloseOutlined}
                             iconSize={14}
-                            color={'#333'}
-                            hoverColor={'#000'}
+                            color={colors.text}
+                            hoverColor={colors.textSecondary}
                             title={'Close panel'}
                             onPress={() => {
                                 props.onShowRightPanel();
@@ -98,7 +102,7 @@ export function RightPanel(props: RightPanelProps) {
     );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     animatedContainer: {
         flexDirection: 'row',
         position: 'relative',
@@ -106,14 +110,7 @@ const styles = StyleSheet.create({
     container: {
         width: rightPanelWidth,
         alignSelf: 'stretch',
-        backgroundColor: '#f8f8f8',
-    },
-    contentContainer: {
-        flexGrow: 1,
-        flexShrink: 0,
-        flexBasis: 0,
-        flexDirection: 'column',
-        alignSelf: 'stretch',
+        backgroundColor: colors.surface,
     },
     headerContainer: {
         flexDirection: 'row',
@@ -121,14 +118,21 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         borderBottomWidth: 1,
         borderStyle: 'solid',
-        borderColor: '#ddd',
+        borderColor: colors.border,
         paddingLeft: 12,
         paddingRight: 4,
     },
     headerTitleText: {
-        color: '#333',
+        color: colors.text,
         fontSize: 14,
         fontWeight: 'bold',
+    },
+    contentContainer: {
+        flexGrow: 1,
+        flexShrink: 0,
+        flexBasis: 0,
+        flexDirection: 'column',
+        alignSelf: 'stretch',
     },
     headerControlsContainer: {
         flex: 1,

--- a/client/SettingsPanel.tsx
+++ b/client/SettingsPanel.tsx
@@ -18,6 +18,7 @@ import {
     configSettingsAlphabetized,
 } from './PyrightConfigSettings';
 import { SettingsCheckbox } from './SettingsCheckBox';
+import { useTheme, ThemeColors } from './ThemeContext';
 
 interface ConfigOptionWithValue {
     name: string;
@@ -31,7 +32,9 @@ export interface SettingsPanelProps {
     onUpdateSettings: (settings: PlaygroundSettings) => void;
 }
 
+
 export function SettingsPanel(props: SettingsPanelProps) {
+    const { colors } = useTheme();
     const typeCheckingModeMenuRef = useRef<MenuRef>(null);
     const configOptionsMenuRef = useRef<MenuRef>(null);
     const pyrightVersionMenuRef = useRef<MenuRef>(null);
@@ -39,6 +42,7 @@ export function SettingsPanel(props: SettingsPanelProps) {
     const pythonPlatformMenuRef = useRef<MenuRef>(null);
     const localeMenuRef = useRef<MenuRef>(null);
     const configOverrides = getNonDefaultConfigOptions(props.settings);
+    const styles = makeStyles(colors);
 
     return (
         <View style={styles.container}>
@@ -272,18 +276,23 @@ export function SettingsPanel(props: SettingsPanelProps) {
 }
 
 function MenuButton(props: { onPress: () => void }) {
+    const { colors } = useTheme();
+
     return (
         <IconButton
             iconDefinition={icons.DownCircleOutlined}
             iconSize={18}
-            color="#ffaa00"
-            hoverColor="#000"
+            color={colors.accent}
+            hoverColor={colors.text}
             onPress={props.onPress}
         />
     );
 }
 
 function SettingsHeader(props: { headerText: string }) {
+    const { colors } = useTheme();
+    const styles = makeStyles(colors);
+
     return (
         <View style={styles.headerTextBox}>
             <Text style={styles.headerText} selectable={false}>
@@ -294,6 +303,9 @@ function SettingsHeader(props: { headerText: string }) {
 }
 
 function SettingsDivider() {
+    const { colors } = useTheme();
+    const styles = makeStyles(colors);
+
     return <View style={styles.divider} />;
 }
 
@@ -303,7 +315,9 @@ interface ConfigOverrideProps {
 }
 
 function ConfigOverride(props: ConfigOverrideProps) {
+    const { colors } = useTheme();
     const text = `${props.config.name}=${props.config.value.toString()}`;
+    const styles = makeStyles(colors);
 
     return (
         <View style={styles.configOverrideContainer}>
@@ -314,8 +328,8 @@ function ConfigOverride(props: ConfigOverrideProps) {
                 <IconButton
                     iconDefinition={icons.CloseOutlined}
                     iconSize={12}
-                    color="#666"
-                    hoverColor="#333"
+                    color={colors.textSecondary}
+                    hoverColor={colors.text}
                     onPress={props.onRemove}
                 />
             </View>
@@ -378,18 +392,19 @@ function toggleConfigOption(settings: PlaygroundSettings, optionName: string): P
     return { ...settings, configOverrides };
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     container: {
         flex: 1,
         flexDirection: 'column',
         alignSelf: 'stretch',
         paddingVertical: 8,
         paddingHorizontal: 12,
+        backgroundColor: colors.surface,
     },
     divider: {
         height: 1,
         borderTopWidth: 1,
-        borderColor: '#eee',
+        borderColor: colors.border,
         borderStyle: 'solid',
         marginVertical: 8,
     },
@@ -398,7 +413,7 @@ const styles = StyleSheet.create({
     },
     headerText: {
         fontSize: 14,
-        color: '#666',
+        color: colors.textSecondary,
         fontVariant: ['small-caps'],
     },
     resetButtonContainer: {
@@ -413,10 +428,12 @@ const styles = StyleSheet.create({
         paddingHorizontal: 16,
         alignItems: 'center',
         flexDirection: 'row',
+        borderRadius: 4,
+        marginBottom: 2,
     },
     selectedOptionText: {
         fontSize: 13,
-        color: '#333',
+        color: colors.text,
         flex: 1,
     },
     overridesContainer: {
@@ -434,6 +451,6 @@ const styles = StyleSheet.create({
     configOverrideText: {
         flex: -1,
         fontSize: 12,
-        color: '#333',
+        color: colors.text,
     },
 });

--- a/client/SettingsPanel.tsx
+++ b/client/SettingsPanel.tsx
@@ -32,7 +32,6 @@ export interface SettingsPanelProps {
     onUpdateSettings: (settings: PlaygroundSettings) => void;
 }
 
-
 export function SettingsPanel(props: SettingsPanelProps) {
     const { colors } = useTheme();
     const typeCheckingModeMenuRef = useRef<MenuRef>(null);

--- a/client/TextWithLink.tsx
+++ b/client/TextWithLink.tsx
@@ -5,6 +5,7 @@
 
 import { Linking, StyleProp, StyleSheet, Text, TextStyle } from 'react-native';
 import { useHover } from './HoverHook';
+import { useTheme, ThemeColors } from './ThemeContext';
 
 interface TextWithLinkProps extends React.PropsWithChildren {
     style?: StyleProp<TextStyle>;
@@ -13,7 +14,9 @@ interface TextWithLinkProps extends React.PropsWithChildren {
 }
 
 export default function TextWithLink(props: TextWithLinkProps) {
+    const { colors } = useTheme();
     const [hoverRef, isHovered] = useHover();
+    const styles = makeStyles(colors);
 
     return (
         <Text
@@ -33,11 +36,11 @@ export default function TextWithLink(props: TextWithLinkProps) {
     );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     default: {
-        color: '#ffaa00',
+        color: colors.accent,
     },
     defaultHover: {
-        color: '#333',
+        color: colors.text,
     },
 });

--- a/client/ThemeContext.tsx
+++ b/client/ThemeContext.tsx
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) Eric Traut
  * Theme context and utilities for dark/light mode support.
  */
 

--- a/client/ThemeContext.tsx
+++ b/client/ThemeContext.tsx
@@ -10,6 +10,7 @@ export type Theme = 'light' | 'dark';
 export interface ThemeColors {
     background: string;
     surface: string;
+    hover: string;
     text: string;
     textSecondary: string;
     border: string;
@@ -24,6 +25,7 @@ export interface ThemeColors {
 const lightTheme: ThemeColors = {
     background: '#ffffff',
     surface: '#f8f9fa',
+    hover: '#eee',
     text: '#212529',
     textSecondary: '#6c757d',
     border: '#dee2e6',
@@ -38,6 +40,7 @@ const lightTheme: ThemeColors = {
 const darkTheme: ThemeColors = {
     background: '#1e1e1e',
     surface: '#252526',
+    hover: '#252526',
     text: '#cccccc',
     textSecondary: '#9d9d9d',
     border: '#404040',

--- a/client/ThemeContext.tsx
+++ b/client/ThemeContext.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Eric Traut
+ * Theme context and utilities for dark/light mode support.
+ */
+
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { Appearance } from 'react-native';
+
+export type Theme = 'light' | 'dark';
+
+export interface ThemeColors {
+    background: string;
+    surface: string;
+    text: string;
+    textSecondary: string;
+    border: string;
+    accent: string;
+    error: string;
+    warning: string;
+    info: string;
+    success: string;
+    shadow: string;
+}
+
+const lightTheme: ThemeColors = {
+    background: '#ffffff',
+    surface: '#f8f9fa',
+    text: '#212529',
+    textSecondary: '#6c757d',
+    border: '#dee2e6',
+    accent: '#ffaa00',
+    error: '#dc3545',
+    warning: '#fd7e14',
+    info: '#0dcaf0',
+    success: '#198754',
+    shadow: 'rgba(0, 0, 0, 0.1)',
+};
+
+const darkTheme: ThemeColors = {
+    background: '#1e1e1e',
+    surface: '#252526',
+    text: '#cccccc',
+    textSecondary: '#9d9d9d',
+    border: '#404040',
+    accent: '#ffaa00',
+    error: '#f14c4c',
+    warning: '#ff8c00',
+    info: '#17a2b8',
+    success: '#28a745',
+    shadow: 'rgba(0, 0, 0, 0.3)',
+};
+
+export interface ThemeContextType {
+    theme: Theme;
+    colors: ThemeColors;
+    isDark: boolean;
+    monacoTheme: string;
+}
+
+const ThemeContext = createContext<ThemeContextType>(undefined);
+
+export interface ThemeProviderProps {
+    children: React.ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+    const [theme, setTheme] = useState<Theme>(
+        () => Appearance.getColorScheme() === 'dark' ? 'dark' : 'light'
+    );
+
+    useEffect(() => {
+        const subscription = Appearance.addChangeListener(({ colorScheme }) => {
+            setTheme(colorScheme === 'dark' ? 'dark' : 'light');
+        });
+
+        return () => subscription?.remove?.();
+    }, []);
+
+    const contextValue = useMemo<ThemeContextType>(() => {
+        return {
+            theme,
+            colors: theme === 'dark' ? darkTheme : lightTheme,
+            isDark: theme === 'dark',
+            monacoTheme: theme === 'dark' ? 'vs-dark' : 'vs',
+        };
+    }, [theme]);
+
+    return (
+        <ThemeContext.Provider value={contextValue}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+export function useTheme(): ThemeContextType {
+    const context = useContext(ThemeContext);
+    if (!context) {
+        throw new Error('useTheme must be used within a ThemeProvider');
+    }
+    return context;
+}


### PR DESCRIPTION
Closes #28.

Relies on [`Appearance.getColorScheme()`](https://reactnative.dev/docs/appearance#example) to get the user preference (which should respect the device's setting), rather than relying on an explicit UI toggle -- similar to how [TypeScript Playground](https://www.typescriptlang.org/play/) ([PR snippet](https://github.com/microsoft/TypeScript-Website/pull/187/files#diff-15235ca34238e99ae2da3a21cadc6dd0795859a25460d348273e4ba1295a9cc7R93-R97)) does it.

In the video, you'll see that I'm able to toggle between light/dark mode using the toggles exposed by the Firefox DevTools.

https://github.com/user-attachments/assets/fc3333ac-7ffd-4bdf-8bbc-dd926b53da35